### PR TITLE
Fix @certik's github path

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ $ ./hashdist/bin/hit build hashstack/examples/proteus.linux2.yaml {% endhighligh
 	<p>
 	  Aron Ahmadia (<a href="https://github.com/ahmadia"
 			   class="user-mention">@ahmadia</a>),
-	  Ondřej Čertík (<a href="/certik" 
+	  Ondřej Čertík (<a href="https://github.com/certik" 
 			    class="user-mention">@certik</a>),
 	  Chris Kees (<a href="https://github.com/cekees" 
 			 class="user-mention">@cekees</a>),


### PR DESCRIPTION
Previously it was pointing to the wrong domain.
