### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@ $ ./hashdist/bin/hit build hashstack/examples/proteus.linux2.yaml {% endhighligh
 
 	<h3> Documentation </h3>
 	<p>
-	The HashDist documentation is currently being revised.  The development version is available <a href="http://hashdist.readthedocs.org/en/latest/">here</a>.
+	The HashDist documentation is currently being revised.  The development version is available <a href="https://hashdist.readthedocs.io/en/latest/">here</a>.
 	</p>
  
 	<h3>Authors and Contributors</h3>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
